### PR TITLE
Bug fix for one-liner diffs

### DIFF
--- a/tests/casefiles/git-oneline-add.diff
+++ b/tests/casefiles/git-oneline-add.diff
@@ -1,0 +1,7 @@
+diff --git a/oneline.txt b/oneline.txt
+new file mode 100644
+index 0000000..f56f98d
+--- /dev/null
++++ b/oneline.txt
+@@ -0,0 +1 @@
++Adding a one-line file.

--- a/tests/casefiles/git-oneline-change.diff
+++ b/tests/casefiles/git-oneline-change.diff
@@ -1,0 +1,7 @@
+diff --git a/oneline.txt b/oneline.txt
+index f56f98d..169ceeb 100644
+--- a/oneline.txt
++++ b/oneline.txt
+@@ -1 +1 @@
+-Adding a one-line file.
++Changed a one-line file.

--- a/tests/casefiles/git-oneline-rm.diff
+++ b/tests/casefiles/git-oneline-rm.diff
@@ -1,0 +1,7 @@
+diff --git a/oneline.txt b/oneline.txt
+deleted file mode 100644
+index 169ceeb..0000000
+--- a/oneline.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-Changed a one-line file.

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -509,6 +509,84 @@ class PatchTestSuite(unittest.TestCase):
 
         self.assertEqual(results, expected)
 
+    def test_git_oneline_add(self):
+        with open('tests/casefiles/git-oneline-add.diff') as f:
+            text = f.read()
+
+        lines = text.splitlines()
+
+        expected = [
+            wtp.patch.diffobj(
+                header=wtp.patch.header(
+                    index_path=None,
+                    old_path='/dev/null',
+                    old_version='0000000',
+                    new_path='oneline.txt',
+                    new_version='f56f98d'
+                ),
+                changes=[
+                    (None, 1, 'Adding a one-line file.')
+                ],
+                text='\n'.join(lines[:34]) + '\n'
+            )
+        ]
+
+        results = list(wtp.parse_patch(text))
+
+        self.assertEqual(results, expected)
+
+    def test_git_oneline_change(self):
+        with open('tests/casefiles/git-oneline-change.diff') as f:
+            text = f.read()
+
+        lines = text.splitlines()
+
+        expected = [
+            wtp.patch.diffobj(
+                header=wtp.patch.header(
+                    index_path=None,
+                    old_path='oneline.txt',
+                    old_version='f56f98d',
+                    new_path='oneline.txt',
+                    new_version='169ceeb'
+                ),
+                changes=[
+                    (1, None, 'Adding a one-line file.'),
+                    (None, 1, 'Changed a one-line file.')
+                ],
+                text='\n'.join(lines[:34]) + '\n'
+            )
+        ]
+
+        results = list(wtp.parse_patch(text))
+        print results
+        self.assertEqual(results, expected)
+
+    def test_git_oneline_rm(self):
+        with open('tests/casefiles/git-oneline-rm.diff') as f:
+            text = f.read()
+
+        lines = text.splitlines()
+
+        expected = [
+            wtp.patch.diffobj(
+                header=wtp.patch.header(
+                    index_path=None,
+                    old_path='oneline.txt',
+                    old_version='169ceeb',
+                    new_path='/dev/null',
+                    new_version='0000000'
+                ),
+                changes=[
+                    (1, None, 'Changed a one-line file.')
+                ],
+                text='\n'.join(lines[:34]) + '\n'
+            )
+        ]
+
+        results = list(wtp.parse_patch(text))
+        print results
+        self.assertEqual(results, expected)
 
     def test_git_header(self):
         text = """

--- a/whatthepatch/patch.py
+++ b/whatthepatch/patch.py
@@ -537,10 +537,10 @@ def parse_unified_diff(text):
                 line = c.group(2)
                 c = None
 
-                if kind == '-' and r != old_len:
+                if kind == '-' and (r != old_len or r == 0):
                     changes.append((old + r, None, line))
                     r += 1
-                elif kind == '+' and i != new_len:
+                elif kind == '+' and (i != new_len or i == 0):
                     changes.append((None, new + i, line))
                     i += 1
                 elif kind == ' ' and r != old_len and i != new_len:


### PR DESCRIPTION
This change fixes unified diff parsing to work correctly for one-liner files. Previously, the parser was giving no output in those situations. 

Steps to reproduce:
```
$ mkdir test_repo
$ cd test_repo
$ git init
$ echo "Adding a one-line file." > oneline.txt
$ git commit -am "Add a file"
$ echo "Changed a one-line file." > oneline.txt
$ git commit -am "Changed a file"
$ git rm oneline.txt
$ git commit -m "Delete a file"
$ git log -p
```

Grab any of the diffs in that git log. None of them would parse correctly. This is because the comparison in `parse_unified_diff` of the line offsets `r`\`i` were bypassing at `0` when no `old_len`/`new_len` value was available.

I've included unit tests and casefile fixtures for this change. This does not break any other unit tests, although there are an unrelated set of 3 tests which are currently broken (as described in issue #1). 

Separately, I did look into to those failing tests and I can see that these are intentional test failures, because they are testing not-yet-implemented features. Yay TDD!