### PR TITLE
Git index revision ids might have more that 7 characters.

### DIFF
--- a/tests/casefiles/git-header-long.diff
+++ b/tests/casefiles/git-header-long.diff
@@ -1,0 +1,6 @@
+diff --git a/bugtrace/patch.py b/bugtrace/patch.py
+index 18910dfd..2456e34f 100644
+--- a/bugtrace/patch.py
++++ b/bugtrace/patch.py
+@@ -8,20 +8,30 @@
+

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -603,6 +603,23 @@ class PatchTestSuite(unittest.TestCase):
         results_main = wtp.patch.parse_header(text)
         self.assertEqual(results_main, expected)
 
+    def test_git_header_long(self):
+        with open('tests/casefiles/git-header-long.diff') as f:
+            text = f.read()
+
+        expected = wtp.patch.header(
+                index_path = None,
+                old_path = 'bugtrace/patch.py',
+                old_version = '18910dfd',
+                new_path = 'bugtrace/patch.py',
+                new_version = '2456e34f')
+
+        results = wtp.patch.parse_git_header(text)
+        self.assertEqual(results, expected)
+
+        results_main = wtp.patch.parse_header(text)
+        self.assertEqual(results_main, expected)
+
     def test_svn_header(self):
         with open('tests/casefiles/svn-header.diff') as f:
             text = f.read()

--- a/whatthepatch/patch.py
+++ b/whatthepatch/patch.py
@@ -41,7 +41,7 @@ default_change = re.compile('^([><]) (.*)$')
 
 # git has a special index header and no end part
 git_diffcmd_header = re.compile('^diff --git a/(.+) b/(.+)$')
-git_header_index = re.compile('^index ([\w]{7})..([\w]{7}) ?(\d*)$')
+git_header_index = re.compile('^index ([a-f0-9]+)..([a-f0-9]+) ?(\d*)$')
 git_header_old_line = re.compile('^--- (.+)$')
 git_header_new_line = re.compile('^\+\+\+ (.+)$')
 git_header_file_mode = re.compile('^(new|deleted) file mode \d{6}$')


### PR DESCRIPTION
In large repositories, commit ids in the index line for git patches can have more than 7 characters. This fixes it by making them variable length. To avoid making the expression too general, I also changed \w to accept only hex characters.