### PR TITLE
Replace nose with pytest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Test
         run: |
-          PYTHONPATH=. py.test --doctest-modules --doctest-glob='*.rst'
+          pytest --doctest-modules --doctest-glob='*.rst'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 nose
+          pip install flake8 pytest
 
       - name: Lint
         run: |
@@ -43,4 +43,4 @@ jobs:
 
       - name: Test
         run: |
-          nosetests --with-doctest --doctest-extension=rst
+          PYTHONPATH=. py.test --doctest-modules --doctest-glob='*.rst'

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-nose = "*"
+pytest = "*"
 flake8 = "*"
 twine = "*"
 black = "*"

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -4,7 +4,7 @@ import whatthepatch as wtp
 from whatthepatch import exceptions
 from whatthepatch.snippets import which
 
-from nose.tools import assert_raises
+import pytest
 import unittest
 from unittest.case import SkipTest
 
@@ -26,7 +26,7 @@ class ApplyTestSuite(unittest.TestCase):
             self.lao = f.read().splitlines()
 
         with open("tests/casefiles/tzu") as f:
-            self.tzu = f.read().splitlines()
+           self.tzu = f.read().splitlines()
 
     def test_truth(self):
         self.assertEqual(type(self.lao), list)
@@ -59,10 +59,10 @@ class ApplyTestSuite(unittest.TestCase):
         with open("tests/casefiles/diff-unified-bad.diff") as f:
             diff_text = f.read()
 
-        with assert_raises(exceptions.ApplyException) as ec:
+        with pytest.raises(exceptions.ApplyException) as ec:
             _apply(self.lao, diff_text)
 
-        e = ec.exception
+        e = ec.value
         e_str = str(e)
         assert "line 4" in e_str
         assert "The Named is the mother of all tings." in e_str
@@ -73,10 +73,10 @@ class ApplyTestSuite(unittest.TestCase):
         with open("tests/casefiles/diff-unified-bad2.diff") as f:
             diff_text = f.read()
 
-        with assert_raises(exceptions.ApplyException) as ec:
+        with pytest.raises(exceptions.ApplyException) as ec:
             _apply(self.lao, diff_text)
 
-        e = ec.exception
+        e = ec.value
         e_str = str(e)
         assert "line 9" in e_str
         assert "The two are te same," in e_str
@@ -87,10 +87,10 @@ class ApplyTestSuite(unittest.TestCase):
         with open("tests/casefiles/diff-unified-bad2.diff") as f:
             diff_text = f.read()
 
-        with assert_raises(exceptions.ApplyException) as ec:
+        with pytest.raises(exceptions.ApplyException) as ec:
             _apply(self.tzu, diff_text)
 
-        e = ec.exception
+        e = ec.value
         e_str = str(e)
         assert "line 1" in e_str
         assert "The Way that can be told of is not the eternal Way;" in e_str
@@ -101,10 +101,10 @@ class ApplyTestSuite(unittest.TestCase):
         with open("tests/casefiles/diff-unified-bad2.diff") as f:
             diff_text = f.read()
 
-        with assert_raises(exceptions.ApplyException) as ec:
+        with pytest.raises(exceptions.ApplyException) as ec:
             _apply("", diff_text)
 
-        e = ec.exception
+        e = ec.value
         e_str = str(e)
         assert "line 1" in e_str
         assert "The Way that can be told of is not the eternal Way;" in e_str
@@ -126,7 +126,7 @@ class ApplyTestSuite(unittest.TestCase):
         new_text = _apply(self.lao, diff_text, use_patch=True)
         self.assertEqual(new_text, (self.tzu, None))
 
-        with assert_raises(exceptions.ApplyException):
+        with pytest.raises(exceptions.ApplyException):
             _apply([""] + self.lao, diff_text, use_patch=True)
 
     def test_diff_rcs(self):


### PR DESCRIPTION
On Python 3.9 or 3.10 nose will stop working, so let us transform the tests to pytest.

Sorry, I do not know how to purge nose from Pipfile.lock, could you please do it yourself?