### PR TITLE
Improve huge_patch test

### DIFF
--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1426,7 +1426,6 @@ class PatchTestSuite(unittest.TestCase):
         self.assertEqual(results[0].header, expected_header)
 
     def test_huge_patch(self):
-        start_time = time.time()
         text = """diff --git a/huge.file b/huge.file
 index 0000000..1111111 100644
 --- a/huge.file
@@ -1442,6 +1441,7 @@ index 0000000..1111111 100644
 """
         for n in range(0, 1000000):
             text += "+" + hex(n) + "\n"
+        start_time = time.time()
         result = list(wtp.patch.parse_patch(text))
         self.assertEqual(1, len(result))
         self.assertEqual(1000007, len(result[0].changes))

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1426,7 +1426,7 @@ class PatchTestSuite(unittest.TestCase):
         self.assertEqual(results[0].header, expected_header)
 
     def test_huge_patch(self):
-        text = """diff --git a/huge.file b/huge.file
+        text_parts = ["""diff --git a/huge.file b/huge.file
 index 0000000..1111111 100644
 --- a/huge.file
 +++ a/huge.file
@@ -1438,9 +1438,9 @@ index 0000000..1111111 100644
 -44444444
 +55555555
 +66666666
-"""
-        for n in range(0, 1000000):
-            text += "+" + hex(n) + "\n"
+"""]
+        text_parts.extend("+" + hex(n) + "\n" for n in range(0, 1000000))
+        text = ''.join(text_parts)
         start_time = time.time()
         result = list(wtp.patch.parse_patch(text))
         self.assertEqual(1, len(result))


### PR DESCRIPTION
The huge_patch test can fail in some python interpreters, e.g. pypy3 or python3.13 in my case, because text data preparation can take long time as it could be very memory intensive.

This PR addresses the issue with following two changes:
1. Move `start_time` measurement to measure only the parsing time but not data preparation. In other words, test will pass even if the test data preparation will take long time.
2. The test data are constructed from smaller parts with help of `''.join()` method, which is more efficient because it minimizes the number of new string objects created.

The PR is related to https://github.com/cscorley/whatthepatch/pull/46
See also https://bugs.gentoo.org/907243