### PR TITLE
fix: incorrect regular expression matching diffcmd

### DIFF
--- a/src/whatthepatch/patch.py
+++ b/src/whatthepatch/patch.py
@@ -19,7 +19,7 @@ file_timestamp_str = "(.+?)(?:\t|:|  +)(.*)"
 # .+? was previously [^:\t\n\r\f\v]+
 
 # general diff regex
-diffcmd_header = re.compile("^diff.* (.+) (.+)$")
+diffcmd_header = re.compile("^diff .* (.+) (.+)$")
 unified_header_index = re.compile("^Index: (.+)$")
 unified_header_old_line = re.compile(r"^--- " + file_timestamp_str + "$")
 unified_header_new_line = re.compile(r"^\+\+\+ " + file_timestamp_str + "$")


### PR DESCRIPTION
current `diffcmd_header`: `^diff.* (.+) (.+)$`
fixed `diffcmd_header`: `^diff .* (.+) (.+)$`

Using the old `diffcmd_header` may result in lines starting with words like "different" being incorrectly matched as a diff header. Fixing this by adding a blank space.

example: [this commit](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=29e1dfcd5150097f32f34891c85a50d9ead19df3) in Linux kernel

<img width="710" alt="image" src="https://github.com/user-attachments/assets/441ae413-e2fb-4c87-9bce-12c5352d866a">
